### PR TITLE
fix: optimize login query

### DIFF
--- a/Acciones/usuario.php
+++ b/Acciones/usuario.php
@@ -20,9 +20,8 @@ $contraseña = mysqli_real_escape_string($conexion, $contraseña);
 
 // Crea una consulta SQL para seleccionar el usuario y la contraseña de la tabla de usuarios
 $sql = "SELECT * FROM usuario WHERE matricula = '$matricula' AND contraseña = '$contraseña'";
-$query = $conexion->query($sql);
-// Ejecuta la consulta SQL
-$resultado = mysqli_query($conexion, $sql);
+// Ejecuta la consulta SQL una sola vez
+$resultado = $conexion->query($sql);
 
 // Verifica si hay errores en la consulta SQL
 if (!$resultado) {
@@ -31,8 +30,8 @@ if (!$resultado) {
 }
 
 // Verifica si el número de filas devueltas por la consulta es igual a 1
-if (mysqli_num_rows($resultado) == 1) {
-    $usuario = $query->fetch_assoc();
+if ($resultado->num_rows == 1) {
+    $usuario = $resultado->fetch_assoc();
     $Id=  $usuario['IdUsuario'];
     $_SESSION['IdUsuario'] = $Id;
     $_SESSION['Contraseña'] = $contraseña;


### PR DESCRIPTION
## Summary
- remove redundant queries in login handler
- fetch user info from single query

## Testing
- `php -l Acciones/usuario.php`


------
https://chatgpt.com/codex/tasks/task_e_6896d8c05d24833198000a7d8ec8ffe7